### PR TITLE
CMakeLists.txt changes to facilitate building on PS Vita

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ if(WIN32)
     set(FREEIMAGE_SRC ${FREEIMAGE_SRC} Source/FreeImage/freeimage_misc.cpp)
 endif()
 
+
 set(FREEIMAGE_TARGETS)
 if(FREEIMAGE_STATIC)
     add_library(FreeImageLiteStatic STATIC ${FREEIMAGE_SRC})
@@ -449,6 +450,30 @@ if(FREEIMAGE_STATIC)
     target_include_directories(FreeImageLiteStatic PUBLIC "${FREEIMAGE_ZLIB_INCLUDE}" "${FREEIMAGE_PNG_INCLUDE}" "${FREEIMAGE_JPEG_INCLUDE}")
     target_compile_definitions(FreeImageLiteStatic PRIVATE ${FreeImage_Defs} "-DFREEIMAGE_LIB")
     list(APPEND FREEIMAGE_TARGETS FreeImageLiteStatic)
+    if(VITA)
+        target_link_libraries(FreeImageLiteStatic
+            jpeg
+            vitaGL
+            SceRtc_stub
+            SceNetCtl_stub
+            SceNet_stub
+            SceLibKernel_stub
+            ScePvf_stub
+            SceAppMgr_stub
+            SceAppUtil_stub
+            ScePgf_stub
+            freetype
+            png
+            SceCommonDialog_stub
+            m
+            z
+            SceGxm_stub
+            SceDisplay_stub
+            SceSysmodule_stub
+            SceTouch_stub
+            vitashark
+        )
+  endif()
 endif()
 
 if(FREEIMAGE_SHARED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,6 @@ cmake_minimum_required(VERSION 3.2)
 if(DEFINED ENV{VITASDK})
     message("VITASDK Defined!")
     message("VITA BUILD!")
-    message("VITA BUILD!")
-    message("VITA BUILD!")
-    message("VITA BUILD!")
-    message("VITA BUILD!")
-    message("VITA BUILD!")
-    message("VITA BUILD!")
     #set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
     set(CMAKE_TOOLCHAIN_FILE "/usr/local/vitasdk/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
 
@@ -63,6 +57,7 @@ if(VITA)
     set(FREEIMAGE_SHARED OFF)
     message("VITA: Use System LibPNG is ON")
     set(FREEIMAGE_USE_SYSTEM_LIBPNG ON)
+    set(FREEIMAGE_USE_SYSTEM_LIBJPEG ON)
 endif()
 
 option(FREEIMAGE_ENABLE_JPEG "Enables JPEG support" ON)
@@ -451,29 +446,30 @@ if(FREEIMAGE_STATIC)
     target_compile_definitions(FreeImageLiteStatic PRIVATE ${FreeImage_Defs} "-DFREEIMAGE_LIB")
     list(APPEND FREEIMAGE_TARGETS FreeImageLiteStatic)
     if(VITA)
-        target_link_libraries(FreeImageLiteStatic
-            jpeg
-            vitaGL
-            SceRtc_stub
-            SceNetCtl_stub
-            SceNet_stub
-            SceLibKernel_stub
-            ScePvf_stub
-            SceAppMgr_stub
-            SceAppUtil_stub
-            ScePgf_stub
-            freetype
-            png
-            SceCommonDialog_stub
-            m
-            z
-            SceGxm_stub
-            SceDisplay_stub
-            SceSysmodule_stub
-            SceTouch_stub
-            vitashark
-        )
-  endif()
+        # target_compile_options(FreeImageLiteStatic PRIVATE --no-pie)
+        # target_link_libraries(FreeImageLiteStatic
+        #     jpeg
+        #     vitaGL
+        #     SceRtc_stub
+        #     SceNetCtl_stub
+        #     SceNet_stub
+        #     SceLibKernel_stub
+        #     ScePvf_stub
+        #     SceAppMgr_stub
+        #     SceAppUtil_stub
+        #     ScePgf_stub
+        #     freetype
+        #     png
+        #     SceCommonDialog_stub
+        #     m
+        #     z
+        #     SceGxm_stub
+        #     SceDisplay_stub
+        #     SceSysmodule_stub
+        #     SceTouch_stub
+        #     vitashark
+        # )
+    endif()
 endif()
 
 if(FREEIMAGE_SHARED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,13 @@
 cmake_minimum_required(VERSION 3.2)
 
 # Axiom Added this 7-10-2021
-if(DEFINED ENV{VITASDK})
+if(Vita=1)
     message("VITASDK Defined!")
     message("VITA BUILD!")
-    #set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
-    set(CMAKE_TOOLCHAIN_FILE "/usr/local/vitasdk/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
-
-    #include("${VITASDK}/share/vita.cmake" REQUIRED)
-    include ("/usr/local/vitasdk/share/vita.cmake" REQUIRED)
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+    include("$ENV{VITASDK}/share/vita.cmake" REQUIRED)
 
     set(VITA 1)
-    # set(VITA_APP_NAME "TheXTech Vita Edition")
-    # set(VITA_TITLEID  "THEXTECH00001")
-    # set(VITA_VERSION  "01.00")
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,30 @@
 cmake_minimum_required(VERSION 3.2)
 
+# Axiom Added this 7-10-2021
+if(DEFINED ENV{VITASDK})
+    message("VITASDK Defined!")
+    message("VITA BUILD!")
+    message("VITA BUILD!")
+    message("VITA BUILD!")
+    message("VITA BUILD!")
+    message("VITA BUILD!")
+    message("VITA BUILD!")
+    message("VITA BUILD!")
+    #set(CMAKE_TOOLCHAIN_FILE "$ENV{VITASDK}/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+    set(CMAKE_TOOLCHAIN_FILE "/usr/local/vitasdk/share/vita.toolchain.cmake" CACHE PATH "toolchain file")
+
+    #include("${VITASDK}/share/vita.cmake" REQUIRED)
+    include ("/usr/local/vitasdk/share/vita.cmake" REQUIRED)
+
+    set(VITA 1)
+    # set(VITA_APP_NAME "TheXTech Vita Edition")
+    # set(VITA_TITLEID  "THEXTECH00001")
+    # set(VITA_VERSION  "01.00")
+
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
+
 ####### ADD PREDEFINED DEFINITIONS:
 SET(FREEIMAGE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 SET(LIBPNG_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Source/3rdParty/LibPNG/)
@@ -31,6 +56,14 @@ option(FREEIMAGE_STATIC "Build static FreeImageLite" ON)
 
 option(FREEIMAGE_USE_SYSTEM_LIBPNG "Use external libPNG and ZLib" OFF)
 option(FREEIMAGE_USE_SYSTEM_LIBJPEG "Use external libJPEG" OFF)
+
+# Axiom Added 7-10-2021
+if(VITA)
+    message("VITA: Static.")
+    set(FREEIMAGE_SHARED OFF)
+    message("VITA: Use System LibPNG is ON")
+    set(FREEIMAGE_USE_SYSTEM_LIBPNG ON)
+endif()
 
 option(FREEIMAGE_ENABLE_JPEG "Enables JPEG support" ON)
 


### PR DESCRIPTION
Similar to SDL-mixer-X, this version of libFreeImageLite uses the PS Vita SDK's built in "system libs" for zlib, libPNG, and libJPEG. 
Also similar to SDL-mixer-X, I recommend building this with `-DCMAKE_BUILD_TYPE=Debug -DVita=1`. These will be passed automatically when building from TheXTech 