### PR TITLE
PluginGIF.cpp: lazily alloc and memset 4 MB compression table

### DIFF
--- a/Source/FreeImage/PluginGIF.cpp
+++ b/Source/FreeImage/PluginGIF.cpp
@@ -278,7 +278,7 @@ int StringTable::CompressEnd(BYTE *buf)
 
 bool StringTable::Compress(BYTE *buf, int *len)
 {
-	if( m_bufferSize == 0 || m_done ) {
+	if( m_bufferSize == 0 || m_done || !m_strmap ) {
 		return false;
 	}
 


### PR DESCRIPTION
This PR speeds up GIF-loading by >10x by allocating the GIF compression table on the first requested compress operation, instead of unconditionally on initialization. It also prevents illegal memory access if the `Compress` operation is invalidly called after failed initialization of the compression table.