### PR TITLE
Full support for reading/writing QOI images

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ set(FREEIMAGE_SRC ${CMAKE_CURRENT_SOURCE_DIR}
     Source/FreeImage/PluginGIF.cpp
     Source/FreeImage/PluginICO.cpp
     Source/FreeImage/PluginPNG.cpp
+    Source/FreeImage/PluginQOI.cpp
     Source/FreeImage/Conversion.cpp
     Source/FreeImage/Conversion16_555.cpp
     Source/FreeImage/Conversion16_565.cpp

--- a/Source/FreeImage.h
+++ b/Source/FreeImage.h
@@ -434,6 +434,7 @@ FI_ENUM(FREE_IMAGE_FORMAT) {
 	FIF_GIF		= 3,
 	FIF_JPEG	= 4
 #endif
+	FIF_DYNLIB_START = 100,
 };
 
 /** Image type used in FreeImage.

--- a/Source/FreeImage.h
+++ b/Source/FreeImage.h
@@ -428,11 +428,13 @@ FI_ENUM(FREE_IMAGE_FORMAT) {
 	FIF_PICT	= 33,
 	FIF_RAW		= 34,
 	FIF_WEBP	= 35,
-	FIF_JXR		= 36
+	FIF_JXR		= 36,
+	FIF_QOI		= 37,
 #else
 	FIF_PNG		= 2,
 	FIF_GIF		= 3,
-	FIF_JPEG	= 4
+	FIF_JPEG	= 4,
+	FIF_QOI		= 5,
 #endif
 	FIF_DYNLIB_START = 100,
 };

--- a/Source/FreeImage/Plugin.cpp
+++ b/Source/FreeImage/Plugin.cpp
@@ -85,13 +85,20 @@ FreeImage_stricmp(const char *s1, const char *s2) {
 // =====================================================================
 
 PluginList::PluginList() :
-m_plugin_map(),
-m_node_count(0) {
-(void)m_node_count;
+m_plugin_map() {
 }
 
 FREE_IMAGE_FORMAT
-PluginList::AddNode(FI_InitProc init_proc, void *instance, const char *format, const char *description, const char *extension, const char *regexpr) {
+PluginList::AddNode(FREE_IMAGE_FORMAT format_id, FI_InitProc init_proc, void *instance, const char *format, const char *description, const char *extension, const char *regexpr) {
+	// find a format_id above all existing formats
+	if (format_id == FIF_DYNLIB_START) {
+		for (map<int, PluginNode *>::iterator i = m_plugin_map.begin(); i != m_plugin_map.end(); ++i) {
+			if (i->first >= format_id) {
+				format_id = (FREE_IMAGE_FORMAT)(i->first + 1);
+			}
+		}
+	}
+
 	if (init_proc != NULL) {
 		PluginNode *node = new(std::nothrow) PluginNode;
 		Plugin *plugin = new(std::nothrow) Plugin;
@@ -122,7 +129,7 @@ PluginList::AddNode(FI_InitProc init_proc, void *instance, const char *format, c
 		// add the node if it wasn't there already
 
 		if (the_format != NULL) {
-			node->m_id = (int)m_plugin_map.size();
+			node->m_id = (int)format_id;
 			node->m_instance = instance;
 			node->m_plugin = plugin;
 			node->m_format = format;
@@ -131,9 +138,9 @@ PluginList::AddNode(FI_InitProc init_proc, void *instance, const char *format, c
 			node->m_regexpr = regexpr;
 			node->m_enabled = TRUE;
 
-			m_plugin_map[(const int)m_plugin_map.size()] = node;
+			m_plugin_map[format_id] = node;
 
-			return (FREE_IMAGE_FORMAT)node->m_id;
+			return format_id;
 		}
 
 		// something went wrong while allocating the plugin... cleanup
@@ -243,52 +250,47 @@ FreeImage_Initialise(BOOL load_local_plugins_only) {
 			The order used to initialize internal plugins below MUST BE the same order
 			as the one used to define the FREE_IMAGE_FORMAT enum.
 			*/
-			s_plugins->AddNode(InitBMP);
-			s_plugins->AddNode(InitICO);
+			s_plugins->AddNode(FIF_BMP, InitBMP);
+			s_plugins->AddNode(FIF_ICO, InitICO);
+			s_plugins->AddNode(FIF_PNG, InitPNG);
+			s_plugins->AddNode(FIF_GIF, InitGIF);
+#if !defined(FREEIMAGE_LITE) || defined(FREEIMAGE_ENABLE_JPEG)
+			s_plugins->AddNode(FIF_JPEG, InitJPEG);
+#endif
 #ifndef FREEIMAGE_LITE //Don't include those fomrmats into "LITE" assembly
-			s_plugins->AddNode(InitJPEG);
-			s_plugins->AddNode(InitJNG);
-			s_plugins->AddNode(InitKOALA);
-			s_plugins->AddNode(InitIFF);
-			s_plugins->AddNode(InitMNG);
-			s_plugins->AddNode(InitPNM, NULL, "PBM", "Portable Bitmap (ASCII)", "pbm", "^P1");
-			s_plugins->AddNode(InitPNM, NULL, "PBMRAW", "Portable Bitmap (RAW)", "pbm", "^P4");
-			s_plugins->AddNode(InitPCD);
-			s_plugins->AddNode(InitPCX);
-			s_plugins->AddNode(InitPNM, NULL, "PGM", "Portable Greymap (ASCII)", "pgm", "^P2");
-			s_plugins->AddNode(InitPNM, NULL, "PGMRAW", "Portable Greymap (RAW)", "pgm", "^P5");
-#endif
-			s_plugins->AddNode(InitPNG);
-#ifndef FREEIMAGE_LITE
-			s_plugins->AddNode(InitPNM, NULL, "PPM", "Portable Pixelmap (ASCII)", "ppm", "^P3");
-			s_plugins->AddNode(InitPNM, NULL, "PPMRAW", "Portable Pixelmap (RAW)", "ppm", "^P6");
-			s_plugins->AddNode(InitRAS);
-			s_plugins->AddNode(InitTARGA);
-			s_plugins->AddNode(InitTIFF);
-			s_plugins->AddNode(InitWBMP);
-			s_plugins->AddNode(InitPSD);
-			s_plugins->AddNode(InitCUT);
-			s_plugins->AddNode(InitXBM);
-			s_plugins->AddNode(InitXPM);
-			s_plugins->AddNode(InitDDS);
-#endif
-			s_plugins->AddNode(InitGIF);
-#if defined(FREEIMAGE_LITE) && defined(FREEIMAGE_ENABLE_JPEG)
-			s_plugins->AddNode(InitJPEG);
-#endif
-#ifndef FREEIMAGE_LITE
-			s_plugins->AddNode(InitHDR);
-			s_plugins->AddNode(InitG3);
-			s_plugins->AddNode(InitSGI);
-			s_plugins->AddNode(InitEXR);
-			s_plugins->AddNode(InitJ2K);
-			s_plugins->AddNode(InitJP2);
-			s_plugins->AddNode(InitPFM);
-			s_plugins->AddNode(InitPICT);
-			s_plugins->AddNode(InitRAW);
-			s_plugins->AddNode(InitWEBP);
+			s_plugins->AddNode(FIF_JNG, InitJNG);
+			s_plugins->AddNode(FIF_KOALA, InitKOALA);
+			s_plugins->AddNode(FIF_IFF, InitIFF);
+			s_plugins->AddNode(FIF_MNG, InitMNG);
+			s_plugins->AddNode(FIF_PBM, InitPNM, NULL, "PBM", "Portable Bitmap (ASCII)", "pbm", "^P1");
+			s_plugins->AddNode(FIF_PBMRAW, InitPNM, NULL, "PBMRAW", "Portable Bitmap (RAW)", "pbm", "^P4");
+			s_plugins->AddNode(FIF_PCD, InitPCD);
+			s_plugins->AddNode(FIF_PCX, InitPCX);
+			s_plugins->AddNode(FIF_PGM, InitPNM, NULL, "PGM", "Portable Greymap (ASCII)", "pgm", "^P2");
+			s_plugins->AddNode(FIF_PGMRAW, InitPNM, NULL, "PGMRAW", "Portable Greymap (RAW)", "pgm", "^P5");
+			s_plugins->AddNode(FIF_PPM, InitPNM, NULL, "PPM", "Portable Pixelmap (ASCII)", "ppm", "^P3");
+			s_plugins->AddNode(FIF_PPMRAW, InitPNM, NULL, "PPMRAW", "Portable Pixelmap (RAW)", "ppm", "^P6");
+			s_plugins->AddNode(FIF_RAS, InitRAS);
+			s_plugins->AddNode(FIF_TARGA, InitTARGA);
+			s_plugins->AddNode(FIF_TIFF, InitTIFF);
+			s_plugins->AddNode(FIF_WBMP, InitWBMP);
+			s_plugins->AddNode(FIF_PSD, InitPSD);
+			s_plugins->AddNode(FIF_CUT, InitCUT);
+			s_plugins->AddNode(FIF_XBM, InitXBM);
+			s_plugins->AddNode(FIF_XPM, InitXPM);
+			s_plugins->AddNode(FIF_DDS, InitDDS);
+			s_plugins->AddNode(FIF_HDR, InitHDR);
+			s_plugins->AddNode(FIF_FAXG3, InitG3);
+			s_plugins->AddNode(FIF_SGI, InitSGI);
+			s_plugins->AddNode(FIF_EXR, InitEXR);
+			s_plugins->AddNode(FIF_J2K, InitJ2K);
+			s_plugins->AddNode(FIF_JP2, InitJP2);
+			s_plugins->AddNode(FIF_PFM, InitPFM);
+			s_plugins->AddNode(FIF_PICT, InitPICT);
+			s_plugins->AddNode(FIF_RAW, InitRAW);
+			s_plugins->AddNode(FIF_WEBP, InitWEBP);
 #	if !(defined(_MSC_VER) && (_MSC_VER <= 1310))
-			s_plugins->AddNode(InitJXR);
+			s_plugins->AddNode(FIF_JXR, InitJXR);
 #	endif // unsupported by MS Visual Studio 2003 !!!
 #endif
 			// external plugin initialization
@@ -334,7 +336,7 @@ FreeImage_Initialise(BOOL load_local_plugins_only) {
 								FARPROC proc_address = GetProcAddress(instance, "_Init@8");
 
 								if (proc_address != NULL) {
-									s_plugins->AddNode((FI_InitProc)proc_address, (void *)instance);
+									s_plugins->AddNode(FIF_DYNLIB_START, (FI_InitProc)proc_address, (void *)instance);
 								} else {
 									FreeLibrary(instance);
 								}
@@ -542,7 +544,7 @@ FreeImage_SaveU(FREE_IMAGE_FORMAT fif, FIBITMAP *dib, const wchar_t *filename, i
 
 FREE_IMAGE_FORMAT DLL_CALLCONV
 FreeImage_RegisterLocalPlugin(FI_InitProc proc_address, const char *format, const char *description, const char *extension, const char *regexpr) {
-    return s_plugins->AddNode(proc_address, NULL, format, description, extension, regexpr);
+    return s_plugins->AddNode(FIF_DYNLIB_START, proc_address, NULL, format, description, extension, regexpr);
 }
 
 #if defined(_WIN32) && !defined(__MINGW32__)
@@ -554,7 +556,7 @@ FreeImage_RegisterExternalPlugin(const char *path, const char *format, const cha
 		if (instance != NULL) {
 			FARPROC proc_address = GetProcAddress(instance, "_Init@8");
 
-			FREE_IMAGE_FORMAT result = s_plugins->AddNode((FI_InitProc)proc_address, (void *)instance, format, description, extension, regexpr);
+			FREE_IMAGE_FORMAT result = s_plugins->AddNode(FIF_DYNLIB_START, (FI_InitProc)proc_address, (void *)instance, format, description, extension, regexpr);
 
 			if (result == FIF_UNKNOWN)
 				FreeLibrary(instance);

--- a/Source/FreeImage/Plugin.cpp
+++ b/Source/FreeImage/Plugin.cpp
@@ -254,6 +254,7 @@ FreeImage_Initialise(BOOL load_local_plugins_only) {
 			s_plugins->AddNode(FIF_ICO, InitICO);
 			s_plugins->AddNode(FIF_PNG, InitPNG);
 			s_plugins->AddNode(FIF_GIF, InitGIF);
+			s_plugins->AddNode(FIF_QOI, InitQOI);
 #if !defined(FREEIMAGE_LITE) || defined(FREEIMAGE_ENABLE_JPEG)
 			s_plugins->AddNode(FIF_JPEG, InitJPEG);
 #endif

--- a/Source/FreeImage/PluginQOI.cpp
+++ b/Source/FreeImage/PluginQOI.cpp
@@ -1,0 +1,568 @@
+// ==========================================================
+// QOI Loader and Writer
+//
+// Design and implementation by
+// - ds-sloth (ds-sloth@wohlnet.ru)
+// - Dominic Szablewski (https://phoboslab.org)
+//
+// This file is part of FreeImage-Lite 3
+//
+// COVERED CODE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS" BASIS, WITHOUT WARRANTY
+// OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES
+// THAT THE COVERED CODE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE
+// OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED
+// CODE IS WITH YOU. SHOULD ANY COVERED CODE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT
+// THE INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+// SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL
+// PART OF THIS LICENSE. NO USE OF ANY COVERED CODE IS AUTHORIZED HEREUNDER EXCEPT UNDER
+// THIS DISCLAIMER.
+//
+// Use at your own risk!
+// ==========================================================
+
+/*
+
+Includes material from qoi.h
+
+Copyright (c) 2021, Dominic Szablewski - https://phoboslab.org
+SPDX-License-Identifier: MIT
+
+*/
+
+#include "FreeImage.h"
+#include "Utilities.h"
+
+#include "../Metadata/FreeImageTag.h"
+
+// ==========================================================
+// Plugin Interface
+// ==========================================================
+
+static int s_format_id;
+
+
+// ==========================================================
+// Plugin Implementation
+// ==========================================================
+
+static const char * DLL_CALLCONV
+Format() {
+	return "QOI";
+}
+
+static const char * DLL_CALLCONV
+Description() {
+	return "Quite Okay Image";
+}
+
+static const char * DLL_CALLCONV
+Extension() {
+	return "qoi";
+}
+
+static const char * DLL_CALLCONV
+RegExpr() {
+	return "^.QOI\r";
+}
+
+static const char * DLL_CALLCONV
+MimeType() {
+	return "image/qoi";
+}
+
+static BOOL DLL_CALLCONV
+Validate(FreeImageIO *io, fi_handle handle) {
+	BYTE qoi_signature[4] = { 'q', 'o', 'i', 'f' };
+	BYTE signature[4] = { 0, 0, 0, 0 };
+
+	io->read_proc(&signature, 1, 4, handle);
+
+	return (memcmp(qoi_signature, signature, 4) == 0);
+}
+
+static BOOL DLL_CALLCONV
+SupportsExportDepth(int depth) {
+	return (
+			(depth == 32)
+		);
+}
+
+static BOOL DLL_CALLCONV
+SupportsExportType(FREE_IMAGE_TYPE type) {
+	return (
+		(type == FIT_BITMAP)
+	);
+}
+
+static BOOL DLL_CALLCONV
+SupportsNoPixels() {
+	return TRUE;
+}
+
+// --------------------------------------------------------------------------
+
+#ifndef QOI_MALLOC
+    #define QOI_MALLOC(sz) malloc(sz)
+    #define QOI_FREE(p)    free(p)
+#endif
+#ifndef QOI_ZEROARR
+    #define QOI_ZEROARR(a) memset((a),0,sizeof(a))
+#endif
+
+#define QOI_SRGB   0
+#define QOI_LINEAR 1
+#define BUF_SIZE 4096
+
+typedef struct {
+    unsigned int width;
+    unsigned int height;
+    unsigned char channels;
+    unsigned char colorspace;
+} qoi_desc;
+
+#include <stdlib.h>
+#include <string.h>
+
+#define QOI_OP_INDEX  0x00 /* 00xxxxxx */
+#define QOI_OP_DIFF   0x40 /* 01xxxxxx */
+#define QOI_OP_LUMA   0x80 /* 10xxxxxx */
+#define QOI_OP_RUN    0xc0 /* 11xxxxxx */
+#define QOI_OP_RGB    0xfe /* 11111110 */
+#define QOI_OP_RGBA   0xff /* 11111111 */
+
+#define QOI_MASK_2    0xc0 /* 11000000 */
+
+#define QOI_COLOR_HASH(C) (C.rgba.r*3 + C.rgba.g*5 + C.rgba.b*7 + C.rgba.a*11)
+#define QOI_MAGIC \
+    (((unsigned int)'q') << 24 | ((unsigned int)'o') << 16 | \
+     ((unsigned int)'i') <<  8 | ((unsigned int)'f'))
+#define QOI_HEADER_SIZE 14
+
+/* 2GB is the max file size that this implementation can safely handle. We guard
+against anything larger than that, assuming the worst case with 5 bytes per
+pixel, rounded down to a nice clean value. 400 million pixels ought to be
+enough for anybody. */
+#define QOI_PIXELS_MAX ((unsigned int)400000000)
+
+typedef union {
+    struct { unsigned char r, g, b, a; } rgba;
+    unsigned int v;
+} qoi_rgba_t;
+
+static const unsigned char qoi_padding[8] = {0,0,0,0,0,0,0,1};
+
+static void qoi_write_32(unsigned char *bytes, int *p, unsigned int v) {
+    bytes[(*p)++] = (0xff000000 & v) >> 24;
+    bytes[(*p)++] = (0x00ff0000 & v) >> 16;
+    bytes[(*p)++] = (0x0000ff00 & v) >> 8;
+    bytes[(*p)++] = (0x000000ff & v);
+}
+
+static unsigned int qoi_read_32(const unsigned char *bytes, int *p) {
+    unsigned int a = bytes[(*p)++];
+    unsigned int b = bytes[(*p)++];
+    unsigned int c = bytes[(*p)++];
+    unsigned int d = bytes[(*p)++];
+    return a << 24 | b << 16 | c << 8 | d;
+}
+
+static void *qoi_encode(const void *data, const qoi_desc *desc, int *out_len) {
+	int i, max_size, p, run;
+	int px_last, px_pos;
+	unsigned char *bytes;
+	const unsigned char *pixels;
+	qoi_rgba_t index[64];
+	qoi_rgba_t px, px_prev;
+
+	if (
+		data == NULL || out_len == NULL || desc == NULL ||
+		desc->width == 0 || desc->height == 0 ||
+		desc->channels < 3 || desc->channels > 4 ||
+		desc->colorspace > 1 ||
+		desc->height >= QOI_PIXELS_MAX / desc->width
+	) {
+		return NULL;
+	}
+
+	max_size =
+		desc->width * desc->height * 4 +
+		QOI_HEADER_SIZE + sizeof(qoi_padding);
+
+	p = 0;
+	bytes = (unsigned char *) QOI_MALLOC(max_size);
+	if (!bytes) {
+		return NULL;
+	}
+
+	qoi_write_32(bytes, &p, QOI_MAGIC);
+	qoi_write_32(bytes, &p, desc->width);
+	qoi_write_32(bytes, &p, desc->height);
+	bytes[p++] = desc->channels;
+	bytes[p++] = desc->colorspace;
+
+
+	pixels = (const unsigned char *)data;
+
+	QOI_ZEROARR(index);
+
+	run = 0;
+	px_prev.rgba.r = 0;
+	px_prev.rgba.g = 0;
+	px_prev.rgba.b = 0;
+	px_prev.rgba.a = 255;
+	px = px_prev;
+
+	size_t px_stride = desc->width * 4;
+	px_last = px_stride - 4;
+
+	for (size_t row = 0; row < desc->height; row += 1) {
+		for (px_pos = px_stride * (desc->height - 1 - row); px_pos < px_stride * (desc->height - row); px_pos += 4) {
+			px.rgba.r = pixels[px_pos + FI_RGBA_RED];
+			px.rgba.g = pixels[px_pos + FI_RGBA_GREEN];
+			px.rgba.b = pixels[px_pos + FI_RGBA_BLUE];
+			px.rgba.a = pixels[px_pos + FI_RGBA_ALPHA];
+
+			if (px.v == px_prev.v) {
+				run++;
+				if (run == 62 || px_pos == px_last) {
+					bytes[p++] = QOI_OP_RUN | (run - 1);
+					run = 0;
+				}
+			}
+			else {
+				int index_pos;
+
+				if (run > 0) {
+					bytes[p++] = QOI_OP_RUN | (run - 1);
+					run = 0;
+				}
+
+				index_pos = QOI_COLOR_HASH(px) & (64 - 1);
+
+				if (index[index_pos].v == px.v) {
+					bytes[p++] = QOI_OP_INDEX | index_pos;
+				}
+				else {
+					index[index_pos] = px;
+
+					if (px.rgba.a == px_prev.rgba.a) {
+						signed char vr = px.rgba.r - px_prev.rgba.r;
+						signed char vg = px.rgba.g - px_prev.rgba.g;
+						signed char vb = px.rgba.b - px_prev.rgba.b;
+
+						signed char vg_r = vr - vg;
+						signed char vg_b = vb - vg;
+
+						if (
+							vr > -3 && vr < 2 &&
+							vg > -3 && vg < 2 &&
+							vb > -3 && vb < 2
+						) {
+							bytes[p++] = QOI_OP_DIFF | (vr + 2) << 4 | (vg + 2) << 2 | (vb + 2);
+						}
+						else if (
+							vg_r >  -9 && vg_r <  8 &&
+							vg   > -33 && vg   < 32 &&
+							vg_b >  -9 && vg_b <  8
+						) {
+							bytes[p++] = QOI_OP_LUMA     | (vg   + 32);
+							bytes[p++] = (vg_r + 8) << 4 | (vg_b +  8);
+						}
+						else {
+							bytes[p++] = QOI_OP_RGB;
+							bytes[p++] = px.rgba.r;
+							bytes[p++] = px.rgba.g;
+							bytes[p++] = px.rgba.b;
+						}
+					}
+					else {
+						bytes[p++] = QOI_OP_RGBA;
+						bytes[p++] = px.rgba.r;
+						bytes[p++] = px.rgba.g;
+						bytes[p++] = px.rgba.b;
+						bytes[p++] = px.rgba.a;
+					}
+				}
+			}
+			px_prev = px;
+		}
+	}
+
+	for (i = 0; i < (int)sizeof(qoi_padding); i++) {
+		bytes[p++] = qoi_padding[i];
+	}
+
+	*out_len = p;
+	return bytes;
+}
+
+static FIBITMAP * DLL_CALLCONV
+Load(FreeImageIO *io, fi_handle handle, int /*page*/, int flags, void * /*data*/) {
+	if (!handle)
+		return NULL;
+
+    FIBITMAP *dib = NULL;
+    FITAG* tag = NULL;
+    unsigned char *bytes = NULL;
+
+	// qoi_decode: local declarations
+    qoi_desc _desc;
+    qoi_desc* const desc = &_desc;
+
+	try {
+		// allocate a read buffer
+		bytes = (unsigned char*)QOI_MALLOC(BUF_SIZE);
+		if (!bytes) {
+			throw FI_MSG_ERROR_MEMORY;
+		}
+
+		BOOL header_only = (flags & FIF_LOAD_NOPIXELS) == FIF_LOAD_NOPIXELS;
+
+		// read header into buffer
+		if(io->read_proc(bytes, 1, QOI_HEADER_SIZE, handle) != QOI_HEADER_SIZE)
+			throw FI_MSG_ERROR_PARSING;
+
+		// qoi_decode: header read
+		int p = 0;
+		unsigned int header_magic = qoi_read_32(bytes, &p);
+		desc->width = qoi_read_32(bytes, &p);
+		desc->height = qoi_read_32(bytes, &p);
+		desc->channels = bytes[p++];
+		desc->colorspace = bytes[p++];
+
+		if (
+			desc->width == 0 || desc->height == 0 ||
+			desc->channels < 3 || desc->channels > 4 ||
+			desc->colorspace > 1 ||
+			header_magic != QOI_MAGIC ||
+			desc->height >= QOI_PIXELS_MAX / desc->width
+		) {
+			throw FI_MSG_ERROR_PARSING;
+		}
+
+		// allocate bitmap
+		dib = FreeImage_AllocateHeaderT(header_only, FIT_BITMAP, desc->width, desc->height, 32, FI_RGBA_RED_MASK, FI_RGBA_GREEN_MASK, FI_RGBA_BLUE_MASK);
+
+		if (!dib) {
+			throw FI_MSG_ERROR_DIB_MEMORY;
+		}
+
+		FreeImage_SetTransparent(dib, TRUE);
+
+		// add tags for channels and colorspace
+		tag = FreeImage_CreateTag();
+		if (!tag) {
+			throw FI_MSG_ERROR_MEMORY;
+		}
+
+		FreeImage_SetTagLength(tag, 1);
+		FreeImage_SetTagCount(tag, 1);
+		FreeImage_SetTagType(tag, FIDT_BYTE);
+
+		FreeImage_SetTagKey(tag, "channels");
+		FreeImage_SetTagValue(tag, &desc->channels);
+		if (!FreeImage_SetMetadata(FIMD_COMMENTS, dib, FreeImage_GetTagKey(tag), tag)) {
+			throw FI_MSG_ERROR_MEMORY;
+		}
+
+		FreeImage_SetTagKey(tag, "colorspace");
+		FreeImage_SetTagValue(tag, &desc->colorspace);
+		if (!FreeImage_SetMetadata(FIMD_COMMENTS, dib, FreeImage_GetTagKey(tag), tag)) {
+			throw FI_MSG_ERROR_MEMORY;
+		}
+
+		FreeImage_DeleteTag(tag);
+		tag = NULL;
+
+		if (header_only)
+		{
+			QOI_FREE(bytes);
+			return dib;
+		}
+
+		// qoi_decode: load pixel data (prep)
+		int buffer_len = io->read_proc(bytes, 1, BUF_SIZE, handle);
+		p = 0;
+
+		unsigned char *pixels;
+		int run = 0;
+
+		qoi_rgba_t index[64];
+		qoi_rgba_t px;
+
+		QOI_ZEROARR(index);
+		px.rgba.r = 0;
+		px.rgba.g = 0;
+		px.rgba.b = 0;
+		px.rgba.a = 255;
+
+		for (uint32_t row = 0; row < desc->height; row++) {
+			// load scanline into buffer
+
+			// get dest
+			unsigned char* pixels = FreeImage_GetScanLine(dib, desc->height - 1 - row);
+
+			// decode scanline
+			for (int px_pos = 0; px_pos < desc->width * 4; px_pos += 4) {
+				if (run > 0) {
+					run--;
+				}
+				else {
+					// if we're going to overrun bytes array, that's a bug!
+					if (p >= buffer_len) {
+						throw FI_MSG_ERROR_PARSING;
+					}
+
+					int b1 = bytes[p++];
+
+					if (b1 == QOI_OP_RGB) {
+						px.rgba.r = bytes[p++];
+						px.rgba.g = bytes[p++];
+						px.rgba.b = bytes[p++];
+					}
+					else if (b1 == QOI_OP_RGBA) {
+						px.rgba.r = bytes[p++];
+						px.rgba.g = bytes[p++];
+						px.rgba.b = bytes[p++];
+						px.rgba.a = bytes[p++];
+					}
+					else if ((b1 & QOI_MASK_2) == QOI_OP_INDEX) {
+						px = index[b1];
+					}
+					else if ((b1 & QOI_MASK_2) == QOI_OP_DIFF) {
+						px.rgba.r += ((b1 >> 4) & 0x03) - 2;
+						px.rgba.g += ((b1 >> 2) & 0x03) - 2;
+						px.rgba.b += ( b1       & 0x03) - 2;
+					}
+					else if ((b1 & QOI_MASK_2) == QOI_OP_LUMA) {
+						int b2 = bytes[p++];
+						int vg = (b1 & 0x3f) - 32;
+						px.rgba.r += vg - 8 + ((b2 >> 4) & 0x0f);
+						px.rgba.g += vg;
+						px.rgba.b += vg - 8 +  (b2       & 0x0f);
+					}
+					else if ((b1 & QOI_MASK_2) == QOI_OP_RUN) {
+						run = (b1 & 0x3f);
+					}
+
+					index[QOI_COLOR_HASH(px) & (64 - 1)] = px;
+
+					// refill buffer if we're in the last eight bytes
+					if (p >= BUF_SIZE - 8) {
+						memcpy(bytes, bytes + BUF_SIZE - 8, 8);
+						buffer_len -= (BUF_SIZE - 8);
+						p -= (BUF_SIZE - 8);
+
+						if (buffer_len == 8) {
+							buffer_len += io->read_proc(bytes + 8, 1, BUF_SIZE - 8, handle);
+						}
+					}
+				}
+
+				pixels[px_pos + FI_RGBA_RED] = px.rgba.r;
+				pixels[px_pos + FI_RGBA_GREEN] = px.rgba.g;
+				pixels[px_pos + FI_RGBA_BLUE] = px.rgba.b;
+				pixels[px_pos + FI_RGBA_ALPHA] = px.rgba.a;
+			}
+		}
+
+		// if there aren't 8 bytes (padding) left, or the padding doesn't match, that's a bug!
+		if (p > buffer_len - 8 || memcmp(&bytes[p], qoi_padding, 8) != 0) {
+			throw FI_MSG_ERROR_PARSING;
+		}
+
+		QOI_FREE(bytes);
+		return dib;
+	} catch (const char *text) {
+		if (NULL != text) {
+			FreeImage_OutputMessageProc(s_format_id, text);
+		}
+	}
+
+	if (dib) {
+		FreeImage_Unload(dib);
+	}
+
+	if (tag) {
+		FreeImage_DeleteTag(tag);
+	}
+
+	if (bytes) {
+		QOI_FREE(bytes);
+	}
+
+	return NULL;
+}
+
+// --------------------------------------------------------------------------
+
+static BOOL DLL_CALLCONV
+Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int /*page*/, int flags, void * /*data*/)
+{
+	if ((dib) && (handle) && FreeImage_GetBPP(dib) == 32 && FreeImage_GetWidth(dib) == FreeImage_GetPitch(dib)) {
+		try {
+			qoi_desc _desc;
+
+			// set width/height
+			_desc.width = FreeImage_GetWidth(dib);
+			_desc.height = FreeImage_GetHeight(dib);
+
+			// load metadata tags from comments
+			FITAG *tag;
+
+			if(FreeImage_GetMetadata(FIMD_COMMENTS, dib, "colorspace", &tag))
+				_desc.colorspace = *(const uint8_t*)FreeImage_GetTagValue(tag);
+			else
+				_desc.colorspace = 0;
+
+			if(FreeImage_GetMetadata(FIMD_COMMENTS, dib, "channels", &tag))
+				_desc.channels = *(const uint8_t*)FreeImage_GetTagValue(tag);
+			else
+				_desc.channels = 0;
+
+			// convert using (roughly vanilla) qoi_encode -- the difference is that it uses FreeImage RGBA offsets, takes a flipped image, and expects RGBA even if channels is 3
+			int encoded_byte_count = 0;
+			uint8_t* encoded = (uint8_t*)qoi_encode(FreeImage_GetBits(dib), &_desc, &encoded_byte_count);
+
+			if (!encoded || !encoded_byte_count)
+				return FALSE;
+
+			// write here
+			bool succ = (io->write_proc(encoded, 1, encoded_byte_count, handle) == encoded_byte_count);
+
+			QOI_FREE(encoded);
+
+			return succ;
+		} catch (const char *text) {
+			FreeImage_OutputMessageProc(s_format_id, text);
+		}
+	}
+
+	return FALSE;
+}
+
+// ==========================================================
+//   Init
+// ==========================================================
+
+void DLL_CALLCONV
+InitQOI(Plugin *plugin, int format_id) {
+	s_format_id = format_id;
+
+	plugin->format_proc = Format;
+	plugin->description_proc = Description;
+	plugin->extension_proc = Extension;
+	plugin->regexpr_proc = RegExpr;
+	plugin->open_proc = NULL;
+	plugin->close_proc = NULL;
+	plugin->pagecount_proc = NULL;
+	plugin->pagecapability_proc = NULL;
+	plugin->load_proc = Load;
+	plugin->save_proc = Save;
+	plugin->validate_proc = Validate;
+	plugin->mime_proc = MimeType;
+	plugin->supports_export_bpp_proc = SupportsExportDepth;
+	plugin->supports_export_type_proc = SupportsExportType;
+	plugin->supports_icc_profiles_proc = NULL;
+	plugin->supports_no_pixels_proc = SupportsNoPixels;
+}

--- a/Source/FreeImage/PluginQOI.cpp
+++ b/Source/FreeImage/PluginQOI.cpp
@@ -499,7 +499,7 @@ Load(FreeImageIO *io, fi_handle handle, int /*page*/, int flags, void * /*data*/
 static BOOL DLL_CALLCONV
 Save(FreeImageIO *io, FIBITMAP *dib, fi_handle handle, int /*page*/, int flags, void * /*data*/)
 {
-	if ((dib) && (handle) && FreeImage_GetBPP(dib) == 32 && FreeImage_GetWidth(dib) == FreeImage_GetPitch(dib)) {
+	if ((dib) && (handle) && FreeImage_GetBPP(dib) == 32 && FreeImage_GetWidth(dib) * 4 == FreeImage_GetPitch(dib)) {
 		try {
 			qoi_desc _desc;
 

--- a/Source/FreeImageLite.h
+++ b/Source/FreeImageLite.h
@@ -431,11 +431,13 @@ FI_ENUM(FREE_IMAGE_FORMAT) {
 	FIF_PICT	= 33,
 	FIF_RAW		= 34,
 	FIF_WEBP	= 35,
-	FIF_JXR		= 36
+	FIF_JXR		= 36,
+	FIF_QOI		= 37,
 #else
 	FIF_PNG		= 2,
 	FIF_GIF		= 3,
-	FIF_JPEG	= 4
+	FIF_JPEG	= 4,
+	FIF_QOI		= 5,
 #endif
 	FIF_DYNLIB_START = 100,
 };

--- a/Source/FreeImageLite.h
+++ b/Source/FreeImageLite.h
@@ -437,6 +437,7 @@ FI_ENUM(FREE_IMAGE_FORMAT) {
 	FIF_GIF		= 3,
 	FIF_JPEG	= 4
 #endif
+	FIF_DYNLIB_START = 100,
 };
 
 /** Image type used in FreeImage.

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -137,6 +137,7 @@ void DLL_CALLCONV InitXPM(Plugin *plugin, int format_id);
 void DLL_CALLCONV InitDDS(Plugin *plugin, int format_id);
 #endif
 void DLL_CALLCONV InitGIF(Plugin *plugin, int format_id);
+void DLL_CALLCONV InitQOI(Plugin *plugin, int format_id);
 #ifndef FREEIMAGE_LITE //Don't include those formats into "LITE" assembly
 void DLL_CALLCONV InitHDR(Plugin *plugin, int format_id);
 void DLL_CALLCONV InitG3(Plugin *plugin, int format_id);

--- a/Source/Plugin.h
+++ b/Source/Plugin.h
@@ -67,7 +67,7 @@ public :
 	PluginList();
 	~PluginList();
 
-	FREE_IMAGE_FORMAT AddNode(FI_InitProc proc, void *instance = NULL, const char *format = 0, const char *description = 0, const char *extension = 0, const char *regexpr = 0);
+	FREE_IMAGE_FORMAT AddNode(FREE_IMAGE_FORMAT format_id, FI_InitProc proc, void *instance = NULL, const char *format = 0, const char *description = 0, const char *extension = 0, const char *regexpr = 0);
 	PluginNode *FindNodeFromFormat(const char *format);
 	PluginNode *FindNodeFromMime(const char *mime);
 	PluginNode *FindNodeFromFIF(int node_id);
@@ -77,7 +77,6 @@ public :
 
 private :
 	std::map<int, PluginNode *> m_plugin_map;
-	int m_node_count;
 };
 
 // ==========================================================

--- a/Wrapper/VB6/src/MFreeImage.bas
+++ b/Wrapper/VB6/src/MFreeImage.bas
@@ -550,6 +550,7 @@ Public Enum FREE_IMAGE_FORMAT
    FIF_RAW = 34
    FIF_WEBP = 35
    FIF_JXR = 36
+   FIF_QOI = 37
 End Enum
 
 ' Image load options
@@ -12084,6 +12085,7 @@ Const FIF_PICT = 1
 Const FIF_RAW = 1
 Const FIF_WEBP = 1
 Const FIF_JXR = 1
+Const FIF_QOI = 1
 
 ' Enum FREE_IMAGE_LOAD_OPTIONS
 Const FREE_IMAGE_LOAD_OPTIONS = 1

--- a/Wrapper/VB6/src/MFreeImageLite.bas
+++ b/Wrapper/VB6/src/MFreeImageLite.bas
@@ -550,6 +550,7 @@ Public Enum FREE_IMAGE_FORMAT
    FIF_RAW = 34
    FIF_WEBP = 35
    FIF_JXR = 36
+   FIF_QOI = 37
 End Enum
 
 ' Image load options
@@ -12050,6 +12051,7 @@ Const FIF_BMP = 1
 Const FIF_ICO = 1
 Const FIF_PNG = 1
 Const FIF_GIF = 1
+Const FIF_QOI = 1
 
 ' Enum FREE_IMAGE_LOAD_OPTIONS
 Const FREE_IMAGE_LOAD_OPTIONS = 1


### PR DESCRIPTION
This PR adds full QOI read/write support to FreeImage Lite.

It includes the following changes:
* Plugins receive explicit format IDs, instead of their formats matching their initialization order.
* Memory-based I/O is significantly sped up by avoiding a loop (possibly over bytes).
* QOI writing is added, with an implementation roughly identical to `qoi_encode` from `qoi.h`. The only difference is that QOI writing always expects a 32-bpp image, and the channels flag is advisory.
* QOI reading is added, with an optimized implementation significantly faster than the one included in `qoi.h`. Again, this implementation treats the channels flag as advisory  and loads all alpha content encoded in the image.

This implementation decodes QOI images 60% faster than libpng decodes PNG images.